### PR TITLE
add pchip type to 5 float interpolation method

### DIFF
--- a/MultiFunPlayer/Common/MathUtils.cs
+++ b/MultiFunPlayer/Common/MathUtils.cs
@@ -22,7 +22,7 @@ public static class MathUtils
         => type switch
         {
             InterpolationType.Step => Interpolation.Step(x0, y0, x),
-            _ => throw new NotSupportedException()
+            _ => throw new NotSupportedException("type " + type)
         };
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -30,7 +30,8 @@ public static class MathUtils
         => type switch
         {
             InterpolationType.Linear => Interpolation.Linear(x0, y0, x1, y1, x),
-            _ => throw new NotSupportedException()
+            InterpolationType.Pchip => Interpolation.Pchip(x0, y0, x1, y1, 0f, 0f, 0f, 0f, x),
+            _ => throw new NotSupportedException("type " + type)
         };
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -39,7 +40,7 @@ public static class MathUtils
         {
             InterpolationType.Pchip => Interpolation.Pchip(x0, y0, x1, y1, x2, y2, x3, y3, x),
             InterpolationType.Makima => Interpolation.Makima(x0, y0, x1, y1, x2, y2, x3, y3, x),
-            _ => throw new NotSupportedException()
+            _ => throw new NotSupportedException("type " + type)
         };
 }
 

--- a/MultiFunPlayer/UI/Controls/ViewModels/ScriptViewModel.cs
+++ b/MultiFunPlayer/UI/Controls/ViewModels/ScriptViewModel.cs
@@ -211,12 +211,17 @@ public class ScriptViewModel : Screen, IDeviceAxisValueProvider, IDisposable,
                     return false;
                 }
 
-                var newValue = keyframes.Interpolate(state.Index, axisPosition, settings.InterpolationType);
-                if (settings.Inverted)
-                    newValue = 1 - newValue;
+                try {
+                    var newValue = keyframes.Interpolate(state.Index, axisPosition, settings.InterpolationType);
+                    if (settings.Inverted)
+                        newValue = 1 - newValue;
 
-                state.Value = newValue;
-                return MathF.Abs(lastValue - newValue) > 0.000001f;
+                    state.Value = newValue;
+                    return MathF.Abs(lastValue - newValue) > 0.000001f;
+                } catch (NotSupportedException ex) {
+                    Logger.Warn("Unsupported Method" + ex.Message);
+                    return false;
+                }
             }
 
             bool UpdateMotionProvider(DeviceAxis axis, AxisState state, AxisSettings settings)


### PR DESCRIPTION
I've managed to trigger this consistently:

```
2022-01-26 21:58:21.9195|INFO|MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel|Received VideoDurationMessage [Duration: 00:00:00]
2022-01-26 21:58:21.9195|INFO|MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel|Received VideoPlayingMessage [IsPlaying: True]
2022-01-26 21:58:22.2753|INFO|MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel|Received VideoDurationMessage [Duration: 00:46:13.0346679]
2022-01-26 21:58:22.9321|INFO|MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel|Skipping to script start at 1239.064s
2022-01-26 21:58:23.9557|FATAL|MultiFunPlayer|System.NotSupportedException: Specified method is not supported.
   at MultiFunPlayer.Common.MathUtils.Interpolate(Single x0, Single y0, Single x1, Single y1, Single x, InterpolationType type)
   at MultiFunPlayer.Common.KeyframeCollection.Interpolate(Int32 index, Single position, InterpolationType interpolationType)
   at MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel.<>c__DisplayClass91_0.<UpdateThread>g__UpdateScript|6(DeviceAxis axis, AxisState state, AxisSettings settings)
   at MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel.<>c__DisplayClass91_0.<UpdateThread>g__UpdateValues|2()
   at MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel.UpdateThread(CancellationToken token)
   at MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel.<.ctor>b__90_7()
   at System.Threading.Thread.StartHelper.Callback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Thread.StartCallback()|System.NotSupportedException: Specified method is not supported.
   at MultiFunPlayer.Common.MathUtils.Interpolate(Single x0, Single y0, Single x1, Single y1, Single x, InterpolationType type)
   at MultiFunPlayer.Common.KeyframeCollection.Interpolate(Int32 index, Single position, InterpolationType interpolationType)
   at MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel.<>c__DisplayClass91_0.<UpdateThread>g__UpdateScript|6(DeviceAxis axis, AxisState state, AxisSettings settings)
   at MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel.<>c__DisplayClass91_0.<UpdateThread>g__UpdateValues|2()
   at MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel.UpdateThread(CancellationToken token)
   at MultiFunPlayer.UI.Controls.ViewModels.ScriptViewModel.<.ctor>b__90_7()
   at System.Threading.Thread.StartHelper.Callback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Thread.StartCallback()
```

I don't know if this is the proper fix, but at least the catching of the exceptions and logging warnings make the app more stable. 

This particular usage with 0's as default for the pchip interpolation seems to works for me.

In case you are wondering, I encounter these while using the SLR app and at least some, maybe all, the funscripts from CzechVR. for example `cvr238-czechvr-3d-5400x2700-60fps-oculusrift_hq_h265.funscript` triggers it consistently for me.