### PR TITLE
Fixing Emby integration

### DIFF
--- a/Source/MultiFunPlayer/MediaSource/ViewModels/EmbyMediaSource.cs
+++ b/Source/MultiFunPlayer/MediaSource/ViewModels/EmbyMediaSource.cs
@@ -123,7 +123,7 @@ internal sealed class EmbyMediaSource(IShortcutManager shortcutManager, IEventAg
                 if (SelectedDeviceId == null)
                     continue;
 
-                var sessionsUri = new Uri(ServerBaseUri, $"/Sessions?api_key={ApiKey}&DeviceId={SelectedDeviceId}");
+                var sessionsUri = new Uri(ServerBaseUri, $"/Sessions?api_key={ApiKey}&InternalDeviceId={SelectedDeviceId}");
                 var response = await client.GetAsync(sessionsUri, token);
                 if (response == null)
                     continue;


### PR DESCRIPTION
Using "InternalDeviceId" instead of "DeviceId" when looking for sessions.
Potentially this could break for old versions of Emby, I'm unable to find when/if this API was changed. Possible resolutions to the breaking change would be a "version" flag or somehow checking which version we're querying.

This is the resolution to 
#199 
