### PR TITLE
Improve Emby integration to use active sessions

### DIFF
--- a/Source/MultiFunPlayer/MediaSource/ViewModels/EmbyMediaSource.cs
+++ b/Source/MultiFunPlayer/MediaSource/ViewModels/EmbyMediaSource.cs
@@ -134,7 +134,9 @@ internal sealed class EmbyMediaSource(IShortcutManager shortcutManager, IEventAg
                 Logger.Trace("Received \"{0}\" from \"{1}\"", message, Name);
                 try
                 {
-                    var o = JArray.Parse(message).Children<JObject>().FirstOrDefault();
+                    var o = JArray.Parse(message).Children<JObject>()
+                            .Where(obj => !String.IsNullOrWhiteSpace(obj?.ToObject<EmbySession>().Item?.Path))
+                            .FirstOrDefault();
                     _currentSession = o?.ToObject<EmbySession>();
                 }
                 catch (JsonException)


### PR DESCRIPTION
When retrieving the list of sessions, instead of simply using "FirstOrDefault", first filter for entries that have playing Media, and choose the first of those.

This addresses issue #201 