### PR TITLE
Add basic The Handy APIv3 / FW4 support

### DIFF
--- a/Source/MultiFunPlayer/OutputTarget/ViewModels/TheHandyV3OutputTarget.cs
+++ b/Source/MultiFunPlayer/OutputTarget/ViewModels/TheHandyV3OutputTarget.cs
@@ -1,0 +1,741 @@
+﻿using MaterialDesignThemes.Wpf.Converters;
+using MultiFunPlayer.Common;
+using MultiFunPlayer.Shortcut;
+using MultiFunPlayer.UI;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NLog;
+using Stylet;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace MultiFunPlayer.OutputTarget.ViewModels;
+
+// The Handy streaming output for firmware version 4 and above (using API v3)
+[DisplayName("The Handy FW4")]
+internal sealed class TheHandyV3OutputTarget(int instanceIndex, IEventAggregator eventAggregator, IDeviceAxisValueProvider valueProvider)
+    : AsyncAbstractOutputTarget(instanceIndex, eventAggregator, valueProvider)
+{
+    HttpClient httpClient;
+
+    const string baseApiUrl = "https://www.handyfeeling.com/api/handy-rest/v3/";
+
+    long clientServerTimeOffset = 100;
+    int streamId = 100;
+    bool isPlaying = false;
+    bool hasInitedStart = false;
+    int tailPointStreamIndex = 0;
+    bool successfullyConnected = false;
+    bool hasAdjustedDiscrepancyTime = false;
+    bool shouldRestart = false;
+    int millisecondsOffset = 900; // Send points 900 ms ahead of time because we need to maintain a buffer. This causes a latency of 900ms that must be compensated for in the L0 offset setting.
+    int numberOfBatchedPoints => (int)Math.Ceiling(millisecondsOffset / 500.0);
+    int[] previousPoints = { 0, 100, 2 };
+    int[] previousCurrentPoints = { -1, -1, -1, -1, -1 };
+    Queue<HspPoint> buffer = new Queue<HspPoint>();
+    DateTime startTime = DateTime.UtcNow;
+    DateTime previousPointTime = DateTime.UtcNow;
+    DateTime lastBufferPushTime = DateTime.UtcNow;
+    int previousTime = 0;
+
+    double position = 0.5;
+    double currentPosition = 0.5;
+    double speed = 1;
+    System.Timers.Timer outputTimer;
+
+    public string ConnectionKey { get; set; } = null;
+    public DeviceAxis SourceAxis { get; set; } = null;
+
+    public override ConnectionStatus Status { get; protected set; }
+    public bool IsConnected => Status == ConnectionStatus.Connected;
+    public bool IsDisconnected => Status == ConnectionStatus.Disconnected;
+    public bool IsConnectBusy => Status is ConnectionStatus.Connecting or ConnectionStatus.Disconnecting;
+    public bool CanToggleConnect => !IsConnectBusy && SourceAxis != null;
+
+    string apiAuthToken = "Y3aHfWBRFhB~x_26oUVZaO1HL_eEW3IV";    // You should probably change this to a key you control, or make it configurable. You can set up their own key on https://user.handyfeeling.com/
+
+    protected override IUpdateContext RegisterUpdateContext(DeviceAxisUpdateType updateType) => updateType switch
+    {
+        DeviceAxisUpdateType.PolledUpdate => new AsyncPolledUpdateContext(),
+        _ => null,
+    };
+
+    public void OnSourceAxisChanged()
+    {
+        if (Status != ConnectionStatus.Connected || SourceAxis == null)
+            return;
+
+        EventAggregator.Publish(new SyncRequestMessage(SourceAxis));
+    }
+
+    protected override ValueTask<bool> OnConnectingAsync(ConnectionType connectionType)
+    {
+        if (connectionType != ConnectionType.AutoConnect)
+            Logger.Info("Connecting to {0} at \"{1}\" [Type: {2}]", Identifier, ConnectionKey, connectionType);
+
+        if (string.IsNullOrWhiteSpace(ConnectionKey))
+            throw new OutputTargetException("Invalid connection key");
+        if (SourceAxis == null)
+            throw new OutputTargetException("Source axis not selected");
+
+        return ValueTask.FromResult(true);
+    }
+
+
+
+    protected override async Task RunAsync(ConnectionType connectionType, CancellationToken token)
+    {
+        httpClient = new HttpClient();
+        httpClient.Timeout = TimeSpan.FromSeconds(6);
+
+        //using var client = NetUtils.CreateHttpClient();
+
+        try
+        {
+            await Start();
+
+            outputTimer = new System.Timers.Timer();
+            outputTimer.Elapsed += OutputTimer_Tick;
+            outputTimer.Interval = 100;
+            outputTimer.Start();
+
+        }
+        catch (Exception e) when (connectionType != ConnectionType.AutoConnect)
+        {
+            Logger.Error(e, "Error when connecting to {0}", Name);
+            _ = DialogHelper.ShowErrorAsync(e, $"Error when connecting to {Name}", "RootDialog");
+            return;
+        }
+        catch
+        {
+            return;
+        }
+
+        try
+        {
+            Status = ConnectionStatus.Connected;
+            EventAggregator.Publish(new SyncRequestMessage());
+
+            await PolledUpdateAsync(SourceAxis, () => !token.IsCancellationRequested, async (_, snapshot, elapsed) =>
+            {
+                Logger.Debug("Begin PolledUpdate [Index From: {0}, Index To: {1}, Duration: {2}, Elapsed: {3}]", snapshot.IndexFrom, snapshot.IndexTo, snapshot.Duration, elapsed);
+                if (snapshot.KeyframeFrom == null || snapshot.KeyframeTo == null)
+                    return;
+
+                if (!AxisSettings[SourceAxis].Enabled)
+                    return;
+
+                // Interpolate toward target position. Sending the position to The Handy is periodically done in a separate thread (OutputTimer_Tick()).
+                // Simply sending the output to The Handy right now doesn't work well, in my experience the streaming protocol needs a steady supply of points to function correctly even if the position hasn't changed.
+                // There is probably a better way of doing this, but I don't know the software well enough to implement it. 
+                if (snapshot.Duration > 0)
+                    speed = (snapshot.KeyframeTo.Value - snapshot.KeyframeFrom.Value) / snapshot.Duration;
+                if (Math.Abs(speed) < 0.6) // Need a minimum speed (because if speed is too low, Handy movement becomes jagged).
+                    speed = (speed > 0) ? 0.6 : -0.6;
+                position = snapshot.KeyframeTo.Value;  
+
+                //Debug.WriteLine($"UPDATE {currentPosition} {speed} {position}");
+            }, token);
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception e)
+        {
+            Logger.Error(e, $"{Identifier} failed with exception");
+            _ = DialogHelper.ShowErrorAsync(e, $"{Identifier} failed with exception", "RootDialog");
+        }
+
+        outputTimer.Stop();
+        outputTimer = null;
+    }
+
+    private void OutputTimer_Tick(object sender, EventArgs e)
+    {
+        if (currentPosition != position) // Interpolate toward target position.
+        {
+            var delta = speed * (outputTimer.Interval / 1000);
+            if (speed > 0)
+            {
+                if (currentPosition + delta > position)
+                    currentPosition = position;
+                else
+                    currentPosition += speed * (outputTimer.Interval / 1000);
+            }
+            else if (speed < 0)
+            {
+                if (currentPosition + delta < position)
+                    currentPosition = position;
+                else
+                    currentPosition += speed * (outputTimer.Interval / 1000);
+            }
+        }
+        InputPosition(currentPosition);
+        //Debug.WriteLine($"tick {currentPosition} {speed} {position}");
+    }
+
+    private static Uri ApiUri(string path) => new($"https://www.handyfeeling.com/api/handy/v2/{path}");
+    private async Task<JObject> ApiReadResponseAsync(HttpResponseMessage message, CancellationToken token)
+    {
+        var response = JObject.Parse(await message.Content.ReadAsStringAsync(token));
+
+        Logger.Trace("{0} api response [Content: {1}]", Identifier, response.ToString(Formatting.None));
+        if (response.TryGetObject(out var error, "error"))
+            throw new OutputTargetException($"Api call failed: {error.ToString(Formatting.None)}");
+
+        return response;
+    }
+
+    private async Task<JObject> ApiGetAsync(HttpClient client, string path, CancellationToken token)
+    {
+        var uri = ApiUri(path);
+        Logger.Trace("{0} api get [URI: {1}]", Identifier, uri);
+
+        var result = await client.GetAsync(uri, token);
+        result.EnsureSuccessStatusCode();
+        return await ApiReadResponseAsync(result, token);
+    }
+
+    private async Task<JObject> ApiPutAsync(HttpClient client, string path, string content, CancellationToken token)
+    {
+        var uri = ApiUri(path);
+        Logger.Trace("{0} api put [URI: {1}, Content: {2}]", Identifier, uri, content);
+
+        var result = await client.PutAsync(ApiUri(path), new StringContent(content, Encoding.UTF8, "application/json"), token);
+        result.EnsureSuccessStatusCode();
+        return await ApiReadResponseAsync(result, token);
+    }
+
+    public override void HandleSettings(JObject settings, SettingsAction action)
+    {
+        base.HandleSettings(settings, action);
+
+        if (action == SettingsAction.Saving)
+        {
+            settings[nameof(SourceAxis)] = SourceAxis != null ? JToken.FromObject(SourceAxis) : null;
+
+            settings[nameof(ConnectionKey)] = ProtectedStringUtils.Protect(ConnectionKey,
+                e => Logger.Warn(e, "Failed to encrypt \"{0}\"", nameof(ConnectionKey)));
+        }
+        else if (action == SettingsAction.Loading)
+        {
+            if (settings.TryGetValue<DeviceAxis>(nameof(SourceAxis), out var sourceAxis))
+                SourceAxis = sourceAxis;
+
+            if (settings.TryGetValue<string>(nameof(ConnectionKey), out var encryptedConnectionKey))
+                ConnectionKey = ProtectedStringUtils.Unprotect(encryptedConnectionKey,
+                    e => Logger.Warn(e, "Failed to decrypt \"{0}\"", nameof(ConnectionKey)));
+        }
+    }
+
+    public override void RegisterActions(IShortcutManager s)
+    {
+        base.RegisterActions(s);
+
+        #region ConnectionKey
+        s.RegisterAction<string>($"{Identifier}::ConnectionKey::Set", s => s.WithLabel("Connection key"), connectionKey => ConnectionKey = connectionKey);
+        #endregion
+
+        #region SourceAxis
+        s.RegisterAction<DeviceAxis>($"{Identifier}::SourceAxis::Set", s => s.WithLabel("Source axis").WithItemsSource(DeviceAxis.All), axis => SourceAxis = axis);
+        #endregion
+    }
+
+    public override void UnregisterActions(IShortcutManager s)
+    {
+        base.UnregisterActions(s);
+        s.UnregisterAction($"{Identifier}::ConnectionKey::Set");
+        s.UnregisterAction($"{Identifier}::SourceAxis::Set");
+    }
+
+    private async Task Start()
+    {
+        if (string.IsNullOrEmpty(ConnectionKey))
+        {
+            Logger.Error("Please enter a connection key before connecting.");
+            return;
+        }
+
+        try
+        {
+            clientServerTimeOffset = await GetClientServerTimeOffset();
+
+            successfullyConnected = false;
+            buffer.Clear();
+            //streamId += 1;
+            tailPointStreamIndex = 0;
+            for (int i = 0; i < 5; i++)
+            {
+                previousCurrentPoints[i] = -1;
+            }
+
+            try
+            {
+
+                await Stop();
+
+                using (var request = new HttpRequestMessage(new HttpMethod("PUT"), baseApiUrl + "hsp/setup"))
+                {
+                    request.Headers.TryAddWithoutValidation("accept", "application/json");
+                    request.Headers.TryAddWithoutValidation("X-Connection-Key", ConnectionKey);
+                    //request.Headers.TryAddWithoutValidation("X-Api-Key", ApiKey);
+                    request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + apiAuthToken);
+
+                    var contentRaw = new
+                    {
+                        streamId = streamId++
+                    };
+                    request.Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(contentRaw));
+                    request.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+
+                    var response = await httpClient.SendAsync(request);
+
+                    if (response != null && response.IsSuccessStatusCode)
+                    {
+                        var responseText = await response.Content.ReadAsStringAsync();
+                        Logger.Debug("Stream setup command response: " + responseText);
+
+                        // Todo check for error code
+
+                        successfullyConnected = true;
+                        //hasStopped = false;
+                        //ErrorMessage = null;
+                        //TriggerStatusChanged();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                //ErrorMessage = "Failed to connect.";
+                //TriggerStatusChanged();
+            }
+            finally
+            {
+                //criticalMessageLock.ReleaseMutex();
+            }
+
+            //TriggerStatusChanged();
+        }
+        catch (Exception e)
+        {
+            Logger.Error("Something went wrong when connecting: " + e.Message);
+            //ErrorMessage = "Something went wrong when connecting: " + e.Message;
+            //TriggerStatusChanged();
+        }
+    }
+
+    // Receive points from input device
+    private async void InputPosition(double position)
+    {
+        if (!successfullyConnected)//&& !hasStopped)
+            return;
+
+        var now = DateTime.UtcNow;
+
+        var flush = false;
+        if (shouldRestart)
+        {
+            shouldRestart = false;
+
+            // Flush
+            using (var request = new HttpRequestMessage(new HttpMethod("PUT"), baseApiUrl + "hsp/flush"))
+            {
+                request.Headers.TryAddWithoutValidation("accept", "application/json");
+                request.Headers.TryAddWithoutValidation("X-Connection-Key", ConnectionKey);
+                //request.Headers.TryAddWithoutValidation("X-Api-Key", ApiKey);
+                request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + apiAuthToken);
+
+                var contentRaw = new
+                {
+                };
+                request.Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(contentRaw));
+                request.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+
+                try
+                {
+                    //Debug.WriteLine("Putting points: " + points.Count + " time: " + startTime.ToLongTimeString());
+                    var response = await httpClient.SendAsync(request);
+                    Logger.Debug("Flushing: " + response?.StatusCode);
+
+                    if (response != null && response.IsSuccessStatusCode)
+                    {
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn("Flushing failed: " + ex.Message);
+                }
+            }
+            // Rewind
+            isPlaying = false;
+        }
+
+        if (!hasInitedStart)
+        {
+            lastBufferPushTime = now;
+            startTime = now;
+            hasInitedStart = true;
+            flush = true;
+        }
+
+        // Record point in buffer
+        buffer.Enqueue(new HspPoint() { Position = position, Time = now });
+
+        if (buffer.Count >= numberOfBatchedPoints) //now >= lastBufferPushTime )//+ Processor.FilterTime)
+        {
+            try
+            {
+                // Push buffer to stream if enough time has passed
+                lastBufferPushTime = now;
+                var points = new List<object>();
+                do
+                {
+                    var point = buffer.Dequeue();
+                    var x = Math.Clamp((int)Math.Round(point.Position * 100), 0, 100);
+
+                    // Add current point
+                    points.Add(new
+                    {
+                        t = (int)(point.Time - startTime).TotalMilliseconds + millisecondsOffset,
+                        x = x
+                    });
+                    tailPointStreamIndex++;
+
+                    previousPoints[2] = previousPoints[1];
+                    previousPoints[1] = previousPoints[0];
+                    previousPoints[0] = x;
+                    previousPointTime = point.Time;
+                }
+                while (buffer.Any());
+
+
+                if (points.Count > 0)
+                {
+                    //var benchmarkTime = DateTime.UtcNow;
+                    using (var request = new HttpRequestMessage(new HttpMethod("PUT"), baseApiUrl + "hsp/add"))
+                    {
+                        request.Headers.TryAddWithoutValidation("accept", "application/json");
+                        request.Headers.TryAddWithoutValidation("X-Connection-Key", ConnectionKey);
+                        //request.Headers.TryAddWithoutValidation("X-Api-Key", ApiKey);
+                        request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + apiAuthToken);
+
+                        var contentRaw = new
+                        {
+                            points = points.ToArray(),
+                            flush = flush,
+                            tailPointStreamIndex = tailPointStreamIndex,
+                        };
+                        request.Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(contentRaw));
+                        request.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+
+                        try
+                        {
+                            //Debug.WriteLine("Putting points: " + points.Count + " time: " + startTime.ToLongTimeString());
+                            var response = await httpClient.SendAsync(request);
+
+                            //Debug.WriteLine("API roundtrip latency: " + (DateTime.UtcNow - benchmarkTime).TotalMilliseconds);
+
+                            if (response != null && response.IsSuccessStatusCode)
+                            {
+                                var responseText = await response.Content.ReadAsStringAsync();
+                                var responseJson = System.Text.Json.JsonSerializer.Deserialize<PutPointsApiResponse>(responseText);
+                                if (responseJson != null)
+                                {
+                                    if (responseJson.result != null)
+                                    {
+
+                                        var isStalled = true;
+                                        for (int i = 0; i < 4; i++)
+                                        {
+                                            if (previousCurrentPoints[i] != previousCurrentPoints[i + 1] && previousCurrentPoints[i] > 0)
+                                                isStalled = false;
+                                            previousCurrentPoints[i] = previousCurrentPoints[i + 1];
+                                        }
+                                        if (previousCurrentPoints[4] != responseJson.result.current_point)
+                                            isStalled = false;
+                                        previousCurrentPoints[4] = responseJson.result.current_point;
+                                        previousTime = responseJson.result.current_time;
+
+                                        if (isStalled)
+                                        {
+                                            Logger.Warn("Stalled");
+                                            //var update = ErrorMessage == null;
+                                            //ErrorMessage = "Stalled! Try increasing latency\nand/or reconnecting.";
+                                            //if (update)
+                                            //    TriggerStatusChanged();
+                                        }
+                                        else
+                                        {
+                                            //var update = ErrorMessage != null;
+                                            //ErrorMessage = null;
+                                            //if (update)
+                                            //TriggerStatusChanged();
+                                        }
+
+                                        if ((responseJson.result.max_points - responseJson.result.points) < 100)
+                                        {
+                                            // Flush and reset point buffer because it gets buggy when reaching max points
+                                            shouldRestart = true;
+                                        }
+                                    }
+                                    else if (responseJson.error != null)
+                                    {
+                                        Logger.Warn("Failed: " + responseJson.error.message);
+                                        if (responseJson.error.code == 1001)
+                                        {
+                                            Logger.Error("The Handy has too old firmware, please update to FW 4 or newer.");
+                                            await DisconnectAsync();
+                                            return;
+                                        }
+                                        if (responseJson.error.name == "DeviceNotConnected")
+                                        {
+                                            Logger.Error("The Handy with this connection code is not online.");
+                                            await DisconnectAsync();
+                                            return;
+                                        }
+                                    }
+                                    Logger.Debug("Point put response: " + responseJson ?? "null");
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            if (ex is not TaskCanceledException)
+                            {
+                                Logger.Warn("Failed: " + ex.Message);
+                                //ErrorMessage = "Failed to send positions";
+                                //TriggerStatusChanged();
+                            }
+                        }
+                    }
+                }
+
+
+                if ((!isPlaying))// && (DateTime.UtcNow - startTime) > TimeSpan.FromSeconds(1)))
+                {
+                    isPlaying = true;
+                    using (var request = new HttpRequestMessage(new HttpMethod("PUT"), baseApiUrl + "hsp/play"))
+                    {
+                        request.Headers.TryAddWithoutValidation("accept", "application/json");
+                        request.Headers.TryAddWithoutValidation("X-Connection-Key", ConnectionKey);
+                        //request.Headers.TryAddWithoutValidation("X-Api-Key", ApiKey);
+                        request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + apiAuthToken);
+
+                        var contentRaw = new
+                        {
+                            startTime = (long)(now - startTime).TotalMilliseconds, //-(int)(DateTime.UtcNow - benchmarkTime).TotalMilliseconds,
+                            serverTime = ((DateTimeOffset)DateTimeOffset.UtcNow.ToUniversalTime()).ToUnixTimeMilliseconds() + clientServerTimeOffset,
+                            playbackRate = 1.0,
+                            loop = false,
+                        };
+                        request.Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(contentRaw));
+                        request.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+
+                        var response = await httpClient.SendAsync(request);
+
+                        if (response != null && response.IsSuccessStatusCode)
+                        {
+                            Logger.Debug("START PLAYING " + startTime.ToLongTimeString());
+                            //if (!hasStopped)
+                            {
+                                //successfullyConnected = true;
+                                Logger.Debug(await response.Content.ReadAsStringAsync());
+                                //isPlaying = true;
+                            }
+                        }
+                        else
+                        {
+                            isPlaying = false;
+                            //ErrorMessage = "Failed to start playing...\nTry again.";
+                            //TriggerStatusChanged();
+                            Logger.Error("Failed to start playing: " + response?.ToString());
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn("Failed to send/process points to The Handy: " + ex.ToString());
+            }
+
+        }
+    }
+
+    private async Task Stop()
+    {
+        successfullyConnected = false;
+        isPlaying = false;
+        //hasStopped = true;
+        hasInitedStart = false;
+        hasAdjustedDiscrepancyTime = false;
+        //httpClient.CancelPendingRequests();
+        //ErrorMessage = null;
+        //TriggerStatusChanged();
+
+        try
+        {
+            // Repeat to make sure there is no race between incoming points
+            for (int i = 0; i < 2; i++)
+            {
+                using (var request = new HttpRequestMessage(new HttpMethod("PUT"), baseApiUrl + "hsp/stop"))
+                {
+                    request.Headers.TryAddWithoutValidation("accept", "application/json");
+                    request.Headers.TryAddWithoutValidation("X-Connection-Key", ConnectionKey);
+                    //request.Headers.TryAddWithoutValidation("X-Api-Key", ApiKey);
+                    request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + apiAuthToken);
+
+                    await httpClient.SendAsync(request);
+
+                }
+                using (var request = new HttpRequestMessage(new HttpMethod("PUT"), baseApiUrl + "hsp/flush"))
+                {
+                    request.Headers.TryAddWithoutValidation("accept", "application/json");
+                    request.Headers.TryAddWithoutValidation("X-Connection-Key", ConnectionKey);
+                    //request.Headers.TryAddWithoutValidation("X-Api-Key", ApiKey);
+                    request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + apiAuthToken);
+
+                    await httpClient.SendAsync(request);
+
+                }
+                await Task.Delay(100);
+            }
+        }
+        catch
+        {
+            return;
+        }
+    }
+
+    // https://ohdoki.notion.site/Handy-API-v3-ea6c47749f854fbcabcc40c729ea6df4 chapter "Synchronized protocols"
+    private async Task<long> GetClientServerTimeOffset()
+    {
+        const int numSamples = 30;
+        int timeout = 10;
+        var stopwatch = new Stopwatch();
+        long offsetTimeSum = 0;
+
+        for (int i = 0; i < numSamples; i++)
+        {
+            using (var request = new HttpRequestMessage(new HttpMethod("GET"), baseApiUrl + "servertime"))
+            {
+                request.Headers.TryAddWithoutValidation("accept", "application/json");
+                request.Headers.TryAddWithoutValidation("X-Connection-Key", ConnectionKey);
+                //request.Headers.TryAddWithoutValidation("X-Api-Key", ApiKey);
+                request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + apiAuthToken);
+
+                /*var contentRaw = new
+                {
+                    ck = ConnectionKey
+                };
+                request.Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(contentRaw));
+                request.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");*/
+
+                stopwatch.Restart();
+                var response = await httpClient.SendAsync(request);
+
+                if (response == null)
+                {
+                    if (timeout-- <= 0)
+                        throw new Exception("Failed to get servertime");
+                    i--;
+                    continue;
+                }
+
+                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                {
+                    var responseText = await response.Content.ReadAsStringAsync();
+                    var responseJson = System.Text.Json.JsonSerializer.Deserialize<ServertimeApiResponse>(responseText);
+                    if (responseJson != null && responseJson.server_time > 0)
+                    {
+                        stopwatch.Stop();
+                        var clientTime = ((DateTimeOffset)DateTimeOffset.UtcNow.ToUniversalTime()).ToUnixTimeMilliseconds();
+                        var rountripDelay = stopwatch.ElapsedMilliseconds;
+                        Logger.Debug("Servertime response: " + responseText);
+                        //if (response.IsSuccessStatusCode)
+                        var serverTime = responseJson.server_time;
+                        var estimatedServerReceiveTime = serverTime + rountripDelay / 2;
+                        var timeOffset = estimatedServerReceiveTime - clientTime;
+                        offsetTimeSum += timeOffset;
+                    }
+                    else
+                    {
+                        if (timeout-- <= 0)
+                            throw new Exception("Failed to get servertime");
+                        i--;
+                        continue;
+                    }
+                }
+                else if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                {
+                    throw new Exception("Unauthorized API key");
+                }
+            }
+        }
+
+        var offset = offsetTimeSum / numSamples;
+        Logger.Debug("CLIENT-SERVER OFFSET: " + offset.ToString());
+        return offset;
+    }
+
+    struct HspPoint
+    {
+        public double Position; // From 0 to 1
+        public DateTime Time;
+    }
+
+
+    protected class PutPointsApiResponse
+    {
+        public PutPointsApiResponseResult? result { get; set; }
+        public ErrorApiResponse? error { get; set; }
+
+        public override string ToString()
+        {
+            return result?.ToString() ?? "Empty";
+        }
+    }
+
+    protected class PutPointsApiResponseResult
+    {
+        public int points { get; set; }
+        public int max_points { get; set; }
+        public int current_point { get; set; }
+        public int current_time { get; set; }
+        public int first_point_time { get; set; }
+        public int last_point_time { get; set; }
+        public int tail_point_stream_index { get; set; }
+
+        public override string ToString()
+        {
+            return $"points={points}, current_point={current_point}, current_time={current_time}, last_point_time={last_point_time}, tail_point_stream_index={tail_point_stream_index}";
+        }
+    }
+
+
+    public class AuthenticationApiResponse
+    {
+        public string token_id { get; set; }
+        public string token { get; set; }
+        public string renew { get; set; }
+    }
+
+
+    public class ErrorApiResponse
+    {
+        public int code { get; set; }
+        public string name { get; set; }
+        public string message { get; set; }
+        public bool connected { get; set; }
+    }
+
+
+    public class ServertimeApiResponse
+    {
+        public long server_time { get; set; }
+    }
+}

--- a/Source/MultiFunPlayer/OutputTarget/Views/TheHandyV3OutputTarget.xaml
+++ b/Source/MultiFunPlayer/OutputTarget/Views/TheHandyV3OutputTarget.xaml
@@ -1,0 +1,230 @@
+﻿<UserControl x:Class="MultiFunPlayer.OutputTarget.Views.TheHandyV3OutputTarget"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:common="clr-namespace:MultiFunPlayer.Common"
+             xmlns:converters="clr-namespace:MultiFunPlayer.UI.Converters"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:material="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:metro="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:s="https://github.com/canton7/Stylet"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:ClassModifier="internal"
+             mc:Ignorable="d">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="UpdateContextTemplates.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <converters:AutoToolTipValueToPercentConverter x:Key="AutoToolTipValueToPercentConverter"/>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Expander Style="{StaticResource MaterialDesignToolBarExpander}"
+              material:ExpanderAssist.HorizontalHeaderPadding="0 0 6 0"
+              Background="{DynamicResource MaterialDesignToolBarBackground}"
+              IsExpanded="{Binding DataContext.ContentVisible, RelativeSource={RelativeSource FindAncestor, AncestorLevel=2, AncestorType={x:Type UserControl}}}">
+        <Expander.Header>
+            <DockPanel Height="36" LastChildFill="False">
+                <Button s:View.ActionTarget="{Binding DataContext.Parent, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}"
+                        DockPanel.Dock="Left"
+                        material:ButtonProgressAssist.IsIndeterminate="True"
+                        material:ButtonProgressAssist.IsIndicatorVisible="{Binding IsConnectBusy}"
+                        material:ButtonProgressAssist.Value="-1"
+                        Command="{s:Action ToggleConnectAsync}"
+                        CommandParameter="{Binding}"
+                        IsEnabled="{Binding CanToggleConnect}">
+                    <Button.Style>
+                        <Style BasedOn="{StaticResource MaterialDesignProgressToolBarButton}" TargetType="{x:Type ButtonBase}">
+                            <Setter Property="ToolTip" Value="Connect"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsConnected}" Value="True">
+                                    <Setter Property="ToolTip" Value="Disconnect"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                    <material:PackIcon Width="19" Height="19">
+                        <material:PackIcon.Style>
+                            <Style BasedOn="{StaticResource {x:Type material:PackIcon}}" TargetType="material:PackIcon">
+                                <Setter Property="Kind" Value="Play"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsConnected}" Value="True">
+                                        <Setter Property="Kind" Value="Stop"/>
+                                        <DataTrigger.EnterActions>
+                                            <BeginStoryboard>
+                                                <Storyboard>
+                                                    <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                                     From="0"
+                                                                     To="1"
+                                                                     Duration="0:0:0.8"/>
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </DataTrigger.EnterActions>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </material:PackIcon.Style>
+                    </material:PackIcon>
+                </Button>
+
+                <ToggleButton DockPanel.Dock="Left"
+                              Style="{StaticResource MaterialDesignToolBarToggleButton}"
+                              IsChecked="{Binding AutoConnectEnabled}"
+                              ToolTip="Auto-connect">
+                    <material:PackIcon Width="20"
+                                       Height="20"
+                                       Kind="MotionPlayOutline"
+                                       Opacity=".56"/>
+                    <material:ToggleButtonAssist.OnContent>
+                        <material:PackIcon Width="20"
+                                           Height="20"
+                                           Kind="MotionPlayOutline"/>
+                    </material:ToggleButtonAssist.OnContent>
+                </ToggleButton>
+
+                <material:PopupBox DockPanel.Dock="Right"
+                                   Style="{StaticResource MaterialDesignToolBarPopupBox}"
+                                   PlacementMode="BottomAndAlignRightEdges"
+                                   StaysOpen="True"
+                                   ToolTip="Update settings">
+                    <material:PopupBox.ToggleContent>
+                        <material:PackIcon Width="20"
+                                           Height="20"
+                                           Kind="TimerCogOutline"/>
+                    </material:PopupBox.ToggleContent>
+                    <StackPanel Width="250" Margin="10 0 10 0">
+                        <TextBlock FontWeight="Bold"
+                                   Text="Polled Update"
+                                   Typography.Capitals="AllSmallCaps"/>
+                        <ContentControl Content="{Binding UpdateContexts[PolledUpdate]}"/>
+                    </StackPanel>
+                </material:PopupBox>
+            </DockPanel>
+        </Expander.Header>
+
+        <StackPanel Margin="20">
+            <TextBlock Margin="0 -15 0 10"
+                       HorizontalAlignment="Center"
+                       FontSize="12"
+                       FontWeight="Bold"
+                       Foreground="{DynamicResource MaterialDesignLightPendingBrush}"
+                       Text="The Handy FW4 support is in experimantal state, the device might not behave correctly"
+                       Typography.Capitals="AllSmallCaps"/>
+
+            <TextBlock Margin="0 -10 0 10"
+                       HorizontalAlignment="Center"
+                       FontSize="12"
+                       FontWeight="Bold"
+                       Foreground="{DynamicResource MaterialDesignBody}"
+                       TextWrapping="Wrap"
+                       Text="NB: You need to adjust the time offset in the L0 settings above until movement is synced. A good starting point is -1.0s"
+                       Typography.Capitals="AllSmallCaps"/>
+
+            <DockPanel IsEnabled="{Binding IsDisconnected}" LastChildFill="True">
+                <DockPanel DockPanel.Dock="Top"
+                           Margin="0 0 0 10"
+                           LastChildFill="False">
+                    <TextBlock Margin="0 0 10 0"
+                               VerticalAlignment="Center"
+                               Text="Source axis:"/>
+                    <ComboBox ItemsSource="{Binding Source={x:Static common:DeviceAxis.All}}"
+                              SelectedItem="{Binding SourceAxis}"
+                              Width="50"
+                              material:TextFieldAssist.HasClearButton="True"/>
+                </DockPanel>
+
+                <DockPanel DockPanel.Dock="Top"
+                           Margin="0 0 0 20"
+                           LastChildFill="True">
+                    <TextBox DockPanel.Dock="Left"
+                             Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                             Margin="0 -12 0 0"
+                             VerticalAlignment="Center"
+                             material:HintAssist.Hint="connection key"
+                             Text="{Binding ConnectionKey}"/>
+                </DockPanel>
+            </DockPanel>
+
+            <TextBlock HorizontalAlignment="Left"
+                       VerticalAlignment="Center"
+                       FontWeight="Bold"
+                       Text="Output Range"
+                       Typography.Capitals="AllSmallCaps"/>
+            <ItemsControl ItemsSource="{Binding AxisSettings}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <UniformGrid Margin="0 0 -13 0"
+                                     Columns="3"
+                                     IsItemsHost="True"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <DockPanel Margin="0 0 20 1" LastChildFill="True">
+                            <ToggleButton DockPanel.Dock="Left"
+                                          Width="20"
+                                          Height="14"
+                                          Padding="0"
+                                          VerticalAlignment="Center"
+                                          IsChecked="{Binding Value.Enabled}">
+                                <ToggleButton.Resources>
+                                    <Style BasedOn="{StaticResource MaterialDesignPaperButton}" TargetType="{x:Type ToggleButton}">
+                                        <Setter Property="material:ElevationAssist.Elevation" Value="Dp0"/>
+                                        <Style.Triggers>
+                                            <Trigger Property="IsChecked" Value="True">
+                                                <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidForegroundBrush}"/>
+                                                <Setter Property="material:RippleAssist.Feedback" Value="{DynamicResource PrimaryHueMidForegroundBrush}"/>
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ToggleButton.Resources>
+
+                                <TextBlock FontSize="10"
+                                           FontWeight="Bold"
+                                           Text="{Binding Key}"/>
+                            </ToggleButton>
+
+                            <Canvas DockPanel.Dock="Right" HorizontalAlignment="Stretch">
+                                <metro:RangeSlider Style="{StaticResource MaterialDesignCompactRangeSlider}"
+                                                   Width="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType={x:Type Canvas}}}"
+                                                   AutoToolTipPlacement="TopLeft"
+                                                   AutoToolTipPrecision="2"
+                                                   IsEnabled="{Binding Value.Enabled}"
+                                                   LowerValue="{Binding Value.Minimum, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                   Maximum="1.00"
+                                                   MinRange="0.01"
+                                                   MinRangeWidth="10"
+                                                   Minimum="0.00"
+                                                   UpperValue="{Binding Value.Maximum, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                   UseLayoutRounding="False">
+                                    <metro:RangeSlider.AutoToolTipLowerValueTemplate>
+                                        <DataTemplate>
+                                            <TextBlock HorizontalAlignment="Right" Text="{Binding Converter={StaticResource AutoToolTipValueToPercentConverter}}"/>
+                                        </DataTemplate>
+                                    </metro:RangeSlider.AutoToolTipLowerValueTemplate>
+                                    <metro:RangeSlider.AutoToolTipUpperValueTemplate>
+                                        <DataTemplate>
+                                            <TextBlock HorizontalAlignment="Right" Text="{Binding Converter={StaticResource AutoToolTipValueToPercentConverter}}"/>
+                                        </DataTemplate>
+                                    </metro:RangeSlider.AutoToolTipUpperValueTemplate>
+                                    <metro:RangeSlider.AutoToolTipRangeValuesTemplate>
+                                        <DataTemplate DataType="{x:Type metro:RangeSliderAutoTooltipValues}">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding LowerValue, Converter={StaticResource AutoToolTipValueToPercentConverter}}"/>
+                                                <TextBlock Text=" - "/>
+                                                <TextBlock Text="{Binding UpperValue, Converter={StaticResource AutoToolTipValueToPercentConverter}}"/>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </metro:RangeSlider.AutoToolTipRangeValuesTemplate>
+                                </metro:RangeSlider>
+                            </Canvas>
+                        </DockPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+    </Expander>
+</UserControl>


### PR DESCRIPTION
Added a new output device, an alternative to the The Handy output device but for devices that have been updated to firmware version 4 or above, using the new API v3.

Some problems:

- This is a quick and dirty job, I copied code from another app of mine and quickly ported it, so the code is not clean, my style probably does not fit the rest of the application, and there's probably some unused code remnants/references. However, it does work. I did the change mostly just for myself, but I figured I'd open the PR in case you want to take it into consideration despite its flaws.

- The new API needs to send points in advance to build up a buffer on the server. As far as I could tell this doesn't mesh with the structure of this software that sends the points in real-time to the output device class. In addition, I find that the new API needs to have points continuously sent to it to not have the buffer underrun, even if the position hasn't changed. So I implemented my own buffer and interpolation and I send points to the API in a separate threaded timer. This creates a delay of around 1s, so the user has to manually change the axis "offset" settings to compensate for the delay, for example to -1.0s, and fine tune until it matches the script. This isn't user friendly. There's probably a better way to do this, to automate the latency, but I didn't study the software enough to know.

- The tab header isn't big enough to show the whole name of the device. I titled my view "The Handy FW4" but in the UI it shows up as "he Handy FW"

- The new API needs an application ID, a sort of public auth key to identify what app is connecting to the API. I created an ID in my account but if you implement this device then you probably want to create your own key so that you can maintain it. Can be done at https://user.handyfeeling.com/